### PR TITLE
address globalprotect decrypt-untrust errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Output:
    Change this to apiX.prismacloud.io and populate it in the configs.yml.  
     Or go here for more information:* https://api.docs.prismacloud.io/
 
+5. If you receive GlobalProtect generates 'self-signed certificate in certificate chain' errors,
+   set ```ca_bundle``` in ```config/configs.yml``` (or set the ```REQUESTS_CA_BUNDLE``` environment variable)
+   to a valid CA bundle including the 'Palo Alto Networks Inc Root CA' used by GlobalProtect.
+   Hint: Copy the bundle provided by the certifi module (locate via 'python -m certifi')
+   and append the 'Palo Alto Networks Inc Root CA'.
+
 ### Run
 
 ```

--- a/config/configs.yml
+++ b/config/configs.yml
@@ -3,4 +3,5 @@ prisma_cloud:
   password: "<APIsecret>"
   customer_name:
   api_base: "api3.prismacloud.io"
+  ca_bundle:
   filename: "CloudAccounts.csv"

--- a/lib/config_helper.py
+++ b/lib/config_helper.py
@@ -9,6 +9,7 @@ class ConfigHelper(object):
         self.rl_pass = config["prisma_cloud"]["password"]
         self.rl_cust = config["prisma_cloud"]["customer_name"]
         self.rl_api_base = config["prisma_cloud"]["api_base"]
+        self.rl_ca_bundle = config["prisma_cloud"]["ca_bundle"]
         self.rl_file_name = config["prisma_cloud"]["filename"]
 
     @classmethod

--- a/main.py
+++ b/main.py
@@ -6,8 +6,9 @@ import csv
 class CompareAccounts():
     def __init__(self):
         self.config = lib.ConfigHelper()
-        self.rl_sess = lib.RLSession(self.config.rl_user, self.config.rl_pass, self.config.rl_cust,
-                                     self.config.rl_api_base)
+        self.rl_sess = lib.RLSession(self.config.rl_user, self.config.rl_pass,
+                                     self.config.rl_cust, self.config.rl_api_base,
+                                     self.config.rl_ca_bundle)
 
     def get_pcs_accounts(self):
         self.url = "https://" + self.config.rl_api_base + "/cloud/name"


### PR DESCRIPTION
## Description

Avoid the dreaded `'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`

## Motivation and Context

GlobalProtect intercepts traffic, with varying degrees of transparency.

## How Has This Been Tested?

Successfully executed with GlobalProtect enabled.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x] I have updated the documentation accordingly.
